### PR TITLE
Admin-Impersonation mit Audit-Trail

### DIFF
--- a/app/Filament/Pages/UserSettingsPage.php
+++ b/app/Filament/Pages/UserSettingsPage.php
@@ -10,6 +10,7 @@ use App\Enums\Region;
 use App\Models\NotificationChannel;
 use App\Models\NotificationType;
 use App\Models\User;
+use App\Services\ImpersonationService;
 use Auth;
 use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
 use DanHarrin\LivewireRateLimiting\WithRateLimiting;
@@ -91,7 +92,13 @@ class UserSettingsPage extends Page implements HasForms
         return [
             Action::make('delete_account')->requiresConfirmation()->schema([
                 TextEntry::make('info')->label('Information')->state('Bist du dir absolut sicher, dass du deinen Account löschen möchtest? Wir löschen alle Daten, die mit dir im Zusammenhang stehen. Diese Aktion kann nicht rückgängig gemacht werden!'),
-            ])->action(function () {
+            ])->hidden(fn (): bool => ImpersonationService::isImpersonating())->action(function () {
+                if (ImpersonationService::isImpersonating()) {
+                    Notification::make()->danger()->title('Nicht möglich')->body('Während einer Impersonation kann der Account nicht gelöscht werden.')->send();
+
+                    return;
+                }
+
                 $user = Auth::user();
 
                 if ($user) {
@@ -120,25 +127,25 @@ class UserSettingsPage extends Page implements HasForms
                                 ->label('Geschlecht')
                                 ->options(Gender::class)
                                 ->native(false)
-                                ->disabled(fn (): bool => ! Auth::user()->canUpdateDemographicData()),
+                                ->disabled(fn (): bool => ! Auth::user()->canUpdateDemographicData() || ImpersonationService::isImpersonating()),
                             DatePicker::make('birthday')
                                 ->label('Geburtstag')
                                 ->nullable()
                                 ->before('today')
                                 ->displayFormat('d.m.Y')
-                                ->disabled(fn (): bool => ! Auth::user()->canUpdateDemographicData()),
+                                ->disabled(fn (): bool => ! Auth::user()->canUpdateDemographicData() || ImpersonationService::isImpersonating()),
                             Select::make('nationality')
                                 ->label('Nationalität')
                                 ->searchable()
                                 ->options(Nationality::class)
                                 ->native(false)
-                                ->disabled(fn (): bool => ! Auth::user()->canUpdateDemographicData()),
+                                ->disabled(fn (): bool => ! Auth::user()->canUpdateDemographicData() || ImpersonationService::isImpersonating()),
                             Select::make('region')
                                 ->label('Region')
                                 ->searchable()
                                 ->options(Region::class)
                                 ->native(false)
-                                ->disabled(fn (): bool => ! Auth::user()->canUpdateDemographicData()),
+                                ->disabled(fn (): bool => ! Auth::user()->canUpdateDemographicData() || ImpersonationService::isImpersonating()),
                         ]),
                         Placeholder::make('info')
                             ->hiddenLabel()
@@ -239,6 +246,12 @@ class UserSettingsPage extends Page implements HasForms
             if ($user->last_data_change === null || Carbon::make($user->last_data_change)->addMonths(2)->isPast()) {
                 // Check if dirty ignore array order and compare
                 if ($aOriginalDemographicData !== $demographicData) {
+                    if (ImpersonationService::isImpersonating()) {
+                        Notification::make()->danger()->title('Nicht möglich')->body('Demografische Daten können während einer Impersonation nicht geändert werden.')->send();
+
+                        return;
+                    }
+
                     $user->update($demographicData);
                     $user->update([
                         'last_data_change' => Carbon::now(),

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -7,6 +7,7 @@ namespace App\Filament\Resources;
 use App\Filament\Resources\UserResource\Pages\ListUsers;
 use App\Filament\Resources\UserResource\Pages\ViewUser;
 use App\Models\User;
+use App\Services\ImpersonationService;
 use Auth;
 use Filament\Actions\Action;
 use Filament\Actions\BulkActionGroup;
@@ -24,6 +25,8 @@ use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Auth\Access\AuthorizationException;
+use Livewire\Component;
 
 class UserResource extends Resource
 {
@@ -117,6 +120,32 @@ class UserResource extends Resource
                     ->action(function (User $record): void {
                         $record->unban();
                         Notification::make()->title('Benutzer entbannt')->success()->send();
+                    }),
+                Action::make('impersonate')
+                    ->label('Impersonieren')
+                    ->icon('heroicon-o-finger-print')
+                    ->color('warning')
+                    ->requiresConfirmation()
+                    ->modalHeading('Als Benutzer agieren')
+                    ->modalDescription(fn (User $record): string => sprintf(
+                        'Du wirst als "%s" eingeloggt. Die Aktion wird protokolliert und endet automatisch nach %d Minuten.',
+                        $record->name,
+                        ImpersonationService::MAX_DURATION_MINUTES,
+                    ))
+                    ->visible(fn (User $record): bool => ! $record->isAdmin()
+                        && ! $record->isBanned()
+                        && $record->isNot(Auth::user())
+                        && ! ImpersonationService::isImpersonating())
+                    ->action(function (User $record, Component $livewire): void {
+                        try {
+                            ImpersonationService::start(Auth::user(), $record);
+                        } catch (AuthorizationException $exception) {
+                            Notification::make()->title('Impersonation nicht möglich')->body($exception->getMessage())->danger()->send();
+
+                            return;
+                        }
+
+                        $livewire->redirect('/pr0p0ll');
                     }),
 
                 DeleteAction::make(),

--- a/app/Http/Controllers/ImpersonationController.php
+++ b/app/Http/Controllers/ImpersonationController.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Services\ImpersonationService;
+use Illuminate\Http\RedirectResponse;
+
+class ImpersonationController extends Controller
+{
+    public function leave(): RedirectResponse
+    {
+        if (ImpersonationService::isImpersonating()) {
+            ImpersonationService::stop();
+        }
+
+        return redirect()->to('/pr0p0ll');
+    }
+}

--- a/app/Http/Middleware/HandleImpersonation.php
+++ b/app/Http/Middleware/HandleImpersonation.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Services\ImpersonationService;
+use Closure;
+use Filament\Notifications\Notification;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class HandleImpersonation
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! ImpersonationService::isImpersonating()) {
+            return $next($request);
+        }
+
+        if (Auth::guest()) {
+            // Der impersonierte User wurde extern ausgeloggt (z.B. durch einen Ban) — aufräumen.
+            ImpersonationService::stop();
+
+            return redirect()->to('/pr0p0ll');
+        }
+
+        if (ImpersonationService::isExpired()) {
+            ImpersonationService::stop();
+
+            Notification::make()
+                ->title('Impersonation abgelaufen')
+                ->body('Die Impersonation wurde nach '.ImpersonationService::MAX_DURATION_MINUTES.' Minuten automatisch beendet.')
+                ->warning()
+                ->send();
+
+            return redirect()->to('/pr0p0ll');
+        }
+
+        $admin = ImpersonationService::originalAdmin();
+
+        if ($admin === null || ! $admin->isAdmin()) {
+            // Original-Admin existiert nicht mehr oder hat seine Rechte verloren — Session beenden.
+            ImpersonationService::stop();
+
+            return redirect()->to('/');
+        }
+
+        if (Auth::user()->isAdmin()) {
+            // Defense-in-depth: ein impersonierter User darf nie Admin sein.
+            ImpersonationService::stop();
+
+            abort(403, 'Impersonation eines Administrators ist nicht erlaubt.');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/ImpersonationLog.php
+++ b/app/Models/ImpersonationLog.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ImpersonationLog extends Model
+{
+    protected $fillable = [
+        'admin_id',
+        'target_id',
+        'ip_address',
+        'user_agent',
+        'started_at',
+        'ended_at',
+    ];
+
+    protected $casts = [
+        'started_at' => 'datetime',
+        'ended_at' => 'datetime',
+    ];
+
+    public function admin(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'admin_id');
+    }
+
+    public function target(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'target_id');
+    }
+}

--- a/app/Providers/Filament/Pr0p0llPanelProvider.php
+++ b/app/Providers/Filament/Pr0p0llPanelProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Providers\Filament;
 
 use App\Filament\Pages\Login;
+use App\Http\Middleware\HandleImpersonation;
 use Cog\Laravel\Ban\Http\Middleware\ForbidBannedUser;
 use Filament\Enums\ThemeMode;
 use Filament\Http\Middleware\Authenticate;
@@ -33,6 +34,11 @@ class Pr0p0llPanelProvider extends PanelProvider
         FilamentView::registerRenderHook(
             PanelsRenderHook::USER_MENU_BEFORE,
             static fn (): View => view('filament.header.aftersearch'),
+        );
+
+        FilamentView::registerRenderHook(
+            PanelsRenderHook::BODY_START,
+            static fn (): View => view('filament.impersonation-banner'),
         );
 
         FilamentView::registerRenderHook(
@@ -83,6 +89,7 @@ class Pr0p0llPanelProvider extends PanelProvider
                 DisableBladeIconComponents::class,
                 DispatchServingFilamentEvent::class,
                 ForbidBannedUser::class,
+                HandleImpersonation::class,
             ])
             ->brandLogo(fn () => view('filament.admin.logo'))
             ->brandLogoHeight('auto')

--- a/app/Services/ImpersonationService.php
+++ b/app/Services/ImpersonationService.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\ImpersonationLog;
+use App\Models\User;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+
+class ImpersonationService
+{
+    public const SESSION_KEY = 'impersonation';
+
+    public const MAX_DURATION_MINUTES = 30;
+
+    /**
+     * Startet eine Impersonation. Einziger erlaubter Einstiegspunkt —
+     * alle Guards laufen serverseitig, die Admin-ID kommt nie aus Request-Input.
+     *
+     * @throws AuthorizationException
+     */
+    public static function start(User $admin, User $target): void
+    {
+        if (! $admin->isAdmin()) {
+            throw new AuthorizationException('Nur Administratoren dürfen impersonieren.');
+        }
+
+        if ($target->isAdmin()) {
+            throw new AuthorizationException('Administratoren können nicht impersoniert werden.');
+        }
+
+        if ($target->isBanned()) {
+            throw new AuthorizationException('Gebannte Benutzer können nicht impersoniert werden.');
+        }
+
+        if ($target->is($admin)) {
+            throw new AuthorizationException('Du kannst dich nicht selbst impersonieren.');
+        }
+
+        if (self::isImpersonating()) {
+            throw new AuthorizationException('Es läuft bereits eine Impersonation.');
+        }
+
+        $impersonationLog = ImpersonationLog::create([
+            'admin_id' => $admin->getKey(),
+            'target_id' => $target->getKey(),
+            'ip_address' => request()->ip(),
+            'user_agent' => request()->userAgent(),
+            'started_at' => Carbon::now(),
+        ]);
+
+        session()->put(self::SESSION_KEY, [
+            'admin_id' => $admin->getKey(),
+            'log_id' => $impersonationLog->getKey(),
+            'expires_at' => Carbon::now()->addMinutes(self::MAX_DURATION_MINUTES)->toIso8601String(),
+        ]);
+
+        // Auth::login() rotiert die Session-ID (Schutz vor Session-Fixation) und behält die Session-Daten.
+        Auth::login($target);
+        self::storePasswordHashInSession($target);
+
+        Log::info('Impersonation gestartet', [
+            'admin_id' => $admin->getKey(),
+            'target_id' => $target->getKey(),
+            'log_id' => $impersonationLog->getKey(),
+        ]);
+    }
+
+    /**
+     * Beendet die Impersonation und stellt den Original-Admin wieder her.
+     * Existiert der Admin nicht mehr oder hat er seine Admin-Rechte verloren,
+     * wird stattdessen ein vollständiger Logout erzwungen.
+     */
+    public static function stop(): void
+    {
+        $aImpersonationData = session()->pull(self::SESSION_KEY);
+
+        if (! is_array($aImpersonationData)) {
+            return;
+        }
+
+        if (isset($aImpersonationData['log_id'])) {
+            ImpersonationLog::whereKey($aImpersonationData['log_id'])
+                ->whereNull('ended_at')
+                ->update(['ended_at' => Carbon::now()]);
+        }
+
+        $admin = User::find($aImpersonationData['admin_id'] ?? null);
+
+        if ($admin === null || ! $admin->isAdmin()) {
+            Auth::logout();
+            session()->invalidate();
+            session()->regenerateToken();
+
+            Log::warning('Impersonation beendet — Original-Admin ungültig, Logout erzwungen', [
+                'admin_id' => $aImpersonationData['admin_id'] ?? null,
+                'log_id' => $aImpersonationData['log_id'] ?? null,
+            ]);
+
+            return;
+        }
+
+        Auth::login($admin);
+        self::storePasswordHashInSession($admin);
+
+        Log::info('Impersonation beendet', [
+            'admin_id' => $admin->getKey(),
+            'log_id' => $aImpersonationData['log_id'] ?? null,
+        ]);
+    }
+
+    public static function isImpersonating(): bool
+    {
+        return session()->has(self::SESSION_KEY);
+    }
+
+    public static function isExpired(): bool
+    {
+        $aImpersonationData = session()->get(self::SESSION_KEY);
+
+        if (! is_array($aImpersonationData) || ! isset($aImpersonationData['expires_at'])) {
+            return true;
+        }
+
+        return Carbon::parse($aImpersonationData['expires_at'])->isPast();
+    }
+
+    public static function originalAdmin(): ?User
+    {
+        $aImpersonationData = session()->get(self::SESSION_KEY);
+
+        if (! is_array($aImpersonationData)) {
+            return null;
+        }
+
+        return User::find($aImpersonationData['admin_id'] ?? null);
+    }
+
+    /**
+     * AuthenticateSession vergleicht den Session-Hash mit dem Passwort des aktuellen Users
+     * und würde nach dem User-Wechsel sonst sofort ausloggen.
+     */
+    private static function storePasswordHashInSession(User $user): void
+    {
+        session()->put('password_hash_'.Auth::getDefaultDriver(), $user->getAuthPassword());
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Http\Middleware\HandleImpersonation;
 use App\Http\Middleware\HandleInertiaRequests;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Application;
@@ -17,6 +18,7 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->web(append: [
             HandleInertiaRequests::class,
+            HandleImpersonation::class,
         ]);
 
         $middleware->trustProxies(

--- a/database/migrations/2026_06_07_151119_create_impersonation_logs_table.php
+++ b/database/migrations/2026_06_07_151119_create_impersonation_logs_table.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('impersonation_logs', function (Blueprint $table) {
+            $table->id();
+            // Audit-Trail muss eine User-Löschung überleben — deshalb nullOnDelete statt cascadeOnDelete.
+            $table->foreignId('admin_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignId('target_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('ip_address', 45)->nullable();
+            $table->string('user_agent')->nullable();
+            $table->timestamp('started_at');
+            $table->timestamp('ended_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('impersonation_logs');
+    }
+};

--- a/resources/views/filament/impersonation-banner.blade.php
+++ b/resources/views/filament/impersonation-banner.blade.php
@@ -1,0 +1,18 @@
+@php
+    $impersonationActive = \App\Services\ImpersonationService::isImpersonating() && auth()->check();
+    $impersonationAdmin = $impersonationActive ? \App\Services\ImpersonationService::originalAdmin() : null;
+@endphp
+
+@if ($impersonationActive)
+    <div style="background-color: #ee4d2e; color: #ffffff; padding: 0.5rem 1rem; display: flex; align-items: center; justify-content: center; gap: 1rem; font-size: 0.875rem; position: sticky; top: 0; z-index: 50;">
+        <span>
+            Du agierst als <strong>{{ auth()->user()->name }}</strong>@if ($impersonationAdmin) (Admin: {{ $impersonationAdmin->name }})@endif — die Sitzung endet automatisch nach {{ \App\Services\ImpersonationService::MAX_DURATION_MINUTES }} Minuten.
+        </span>
+        <form method="POST" action="{{ route('impersonation.leave') }}">
+            @csrf
+            <button type="submit" style="background-color: #ffffff; color: #ee4d2e; border: none; border-radius: 0.375rem; padding: 0.25rem 0.75rem; font-weight: 600; cursor: pointer;">
+                Beenden
+            </button>
+        </form>
+    </div>
+@endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\Frontend\FrontendController;
+use App\Http\Controllers\ImpersonationController;
 use App\Http\Controllers\LoginRedirectController;
 use App\Http\Controllers\PollResultImageController;
 use App\Http\Controllers\PollResultRenderController;
@@ -22,6 +23,11 @@ Route::get('/umfragen/{poll}/auswertung', PollResultRenderController::class)
 // Download des asynchron erzeugten Auswertungs-Screenshots (verlinkt aus der Notification).
 Route::get('/umfragen/{poll}/auswertung-bild', PollResultImageController::class)
     ->name('poll.results.image')
+    ->middleware('auth');
+
+// Beendet eine aktive Admin-Impersonation (POST + CSRF, kein GET — verhindert erzwungene Beendigung per Link).
+Route::post('/impersonation/beenden', [ImpersonationController::class, 'leave'])
+    ->name('impersonation.leave')
     ->middleware('auth');
 
 Route::middleware(['guest'])->group(function () {

--- a/tests/Feature/Impersonation/ImpersonationTest.php
+++ b/tests/Feature/Impersonation/ImpersonationTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\ImpersonationLog;
+use App\Models\User;
+use App\Services\ImpersonationService;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Auth;
+
+beforeEach(function (): void {
+    $this->admin = User::factory()->create(['admin' => true]);
+    $this->target = User::factory()->create();
+});
+
+function aktiveImpersonationSession(User $admin, ImpersonationLog $impersonationLog, ?Carbon $expiresAt = null): array
+{
+    return [
+        ImpersonationService::SESSION_KEY => [
+            'admin_id' => $admin->getKey(),
+            'log_id' => $impersonationLog->getKey(),
+            'expires_at' => ($expiresAt ?? Carbon::now()->addMinutes(ImpersonationService::MAX_DURATION_MINUTES))->toIso8601String(),
+        ],
+    ];
+}
+
+function impersonationLogFuer(User $admin, User $target): ImpersonationLog
+{
+    return ImpersonationLog::create([
+        'admin_id' => $admin->getKey(),
+        'target_id' => $target->getKey(),
+        'started_at' => Carbon::now(),
+    ]);
+}
+
+it('startet eine Impersonation als Admin und protokolliert sie', function (): void {
+    $this->actingAs($this->admin);
+
+    ImpersonationService::start($this->admin, $this->target);
+
+    expect(Auth::id())->toBe($this->target->getKey())
+        ->and(ImpersonationService::isImpersonating())->toBeTrue()
+        ->and(ImpersonationService::originalAdmin()?->getKey())->toBe($this->admin->getKey());
+
+    $impersonationLog = ImpersonationLog::sole();
+    expect($impersonationLog->admin_id)->toBe($this->admin->getKey())
+        ->and($impersonationLog->target_id)->toBe($this->target->getKey())
+        ->and($impersonationLog->started_at)->not->toBeNull()
+        ->and($impersonationLog->ended_at)->toBeNull();
+});
+
+it('rotiert die Session-ID beim Start gegen Session-Fixation', function (): void {
+    $this->actingAs($this->admin);
+    $oldSessionId = session()->getId();
+
+    ImpersonationService::start($this->admin, $this->target);
+
+    expect(session()->getId())->not->toBe($oldSessionId);
+});
+
+it('verweigert den Start für Non-Admins', function (): void {
+    $otherUser = User::factory()->create();
+
+    ImpersonationService::start($this->target, $otherUser);
+})->throws(AuthorizationException::class, 'Nur Administratoren dürfen impersonieren.');
+
+it('verweigert die Impersonation eines Admins', function (): void {
+    $otherAdmin = User::factory()->create(['admin' => true]);
+
+    ImpersonationService::start($this->admin, $otherAdmin);
+})->throws(AuthorizationException::class, 'Administratoren können nicht impersoniert werden.');
+
+it('verweigert die Impersonation eines gebannten Benutzers', function (): void {
+    $this->target->ban();
+    $this->target->refresh();
+
+    ImpersonationService::start($this->admin, $this->target);
+})->throws(AuthorizationException::class, 'Gebannte Benutzer können nicht impersoniert werden.');
+
+it('verweigert Selbst-Impersonation', function (): void {
+    ImpersonationService::start($this->admin, $this->admin);
+})->throws(AuthorizationException::class);
+
+it('verweigert verschachtelte Impersonation', function (): void {
+    $this->actingAs($this->admin);
+    ImpersonationService::start($this->admin, $this->target);
+
+    ImpersonationService::start($this->admin, User::factory()->create());
+})->throws(AuthorizationException::class, 'Es läuft bereits eine Impersonation.');
+
+it('stellt den Admin bei stop wieder her und schließt das Protokoll', function (): void {
+    $this->actingAs($this->admin);
+    ImpersonationService::start($this->admin, $this->target);
+
+    ImpersonationService::stop();
+
+    expect(Auth::id())->toBe($this->admin->getKey())
+        ->and(ImpersonationService::isImpersonating())->toBeFalse()
+        ->and(ImpersonationLog::sole()->ended_at)->not->toBeNull();
+});
+
+it('erzwingt Logout bei stop wenn der Original-Admin kein Admin mehr ist', function (): void {
+    $this->actingAs($this->admin);
+    ImpersonationService::start($this->admin, $this->target);
+
+    $this->admin->forceFill(['admin' => false])->save();
+    ImpersonationService::stop();
+
+    expect(Auth::guest())->toBeTrue()
+        ->and(ImpersonationLog::sole()->ended_at)->not->toBeNull();
+});
+
+it('beendet eine abgelaufene Impersonation automatisch per Middleware', function (): void {
+    $impersonationLog = impersonationLogFuer($this->admin, $this->target);
+
+    $this->actingAs($this->target)
+        ->withSession(aktiveImpersonationSession($this->admin, $impersonationLog, Carbon::now()->subMinute()))
+        ->get('/pr0p0ll')
+        ->assertRedirect('/pr0p0ll');
+
+    $this->assertAuthenticatedAs($this->admin);
+    expect($impersonationLog->fresh()->ended_at)->not->toBeNull();
+});
+
+it('bricht mit 403 ab wenn der impersonierte User Admin ist', function (): void {
+    $adminTarget = User::factory()->create(['admin' => true]);
+    $impersonationLog = impersonationLogFuer($this->admin, $adminTarget);
+
+    $this->actingAs($adminTarget)
+        ->withSession(aktiveImpersonationSession($this->admin, $impersonationLog))
+        ->get('/pr0p0ll')
+        ->assertForbidden();
+
+    expect($impersonationLog->fresh()->ended_at)->not->toBeNull();
+});
+
+it('beendet die Impersonation wenn der Original-Admin gelöscht wurde', function (): void {
+    $impersonationLog = impersonationLogFuer($this->admin, $this->target);
+    $aSessionData = aktiveImpersonationSession($this->admin, $impersonationLog);
+    $this->admin->delete();
+
+    $this->actingAs($this->target)
+        ->withSession($aSessionData)
+        ->get('/pr0p0ll')
+        ->assertRedirect('/');
+
+    expect($impersonationLog->fresh()->ended_at)->not->toBeNull();
+});
+
+it('stellt den Admin über die Leave-Route wieder her', function (): void {
+    $impersonationLog = impersonationLogFuer($this->admin, $this->target);
+
+    $this->actingAs($this->target)
+        ->withSession(aktiveImpersonationSession($this->admin, $impersonationLog))
+        ->post(route('impersonation.leave'))
+        ->assertRedirect('/pr0p0ll');
+
+    $this->assertAuthenticatedAs($this->admin);
+    expect($impersonationLog->fresh()->ended_at)->not->toBeNull();
+});
+
+it('lässt die Leave-Route ohne aktive Impersonation ins Leere laufen', function (): void {
+    $this->actingAs($this->admin)
+        ->post(route('impersonation.leave'))
+        ->assertRedirect('/pr0p0ll');
+
+    $this->assertAuthenticatedAs($this->admin);
+});
+
+it('verlangt Authentifizierung für die Leave-Route', function (): void {
+    $this->post(route('impersonation.leave'))->assertRedirect();
+});
+
+it('räumt die Session auf wenn der impersonierte User extern ausgeloggt wurde', function (): void {
+    $impersonationLog = impersonationLogFuer($this->admin, $this->target);
+
+    $this->withSession(aktiveImpersonationSession($this->admin, $impersonationLog))
+        ->get('/')
+        ->assertRedirect('/pr0p0ll');
+
+    $this->assertAuthenticatedAs($this->admin);
+    expect($impersonationLog->fresh()->ended_at)->not->toBeNull();
+});


### PR DESCRIPTION
## Was

Admins können sich im Filament-Panel als Non-Admin-User ausgeben (Support-Debugging). Auslösung über neue Action „Impersonieren" in der `UserResource`, Banner mit Exit-Button im Panel.

## Sicherheits-Design

- **Guards serverseitig** in `ImpersonationService::start()`: nur Admins dürfen starten; Admins, gebannte User, sich selbst und verschachtelte Impersonation sind als Ziel ausgeschlossen
- **Session-Fixation-Schutz**: Session-ID-Rotation bei Start und Stop; `AuthenticateSession`-Hash wird beim User-Wechsel synchronisiert
- **Admin-ID nur aus der Session**, nie aus Request-Input
- **Auto-Expiry nach 30 Minuten** per Middleware; Original-Admin wird bei jedem Request re-validiert (gelöscht/degradiert → Zwangsende)
- **Defense-in-depth**: impersonierter User mit `admin=true` → sofortiger Abbruch mit 403 (deckt das `canAccessPanel()`-allow-all-TODO ab)
- **Audit-Trail**: `impersonation_logs` (admin, target, IP, User-Agent, Start/Ende, `nullOnDelete` — überlebt User-Löschung) + Log-Einträge
- **Geblockt während Impersonation**: Account-Löschung und Demografie-Änderung (UI + serverseitig in `UserSettingsPage`). Umfrage-Teilnahme bleibt bewusst erlaubt (Bug-Repro) — verbraucht die echte Teilnahme des Users
- **Exit nur per POST + CSRF** (`/impersonation/beenden`)

## Tests

`tests/Feature/Impersonation/ImpersonationTest.php` — 16 Tests / 51 Assertions: alle Guards, Expiry, Middleware-Konsistenz-Checks, Leave-Route, Session-Rotation, Audit-Rows. Gesamte Suite grün (84 passed, 230 assertions).

## Hinweis

Beim Review aufgefallen: KB/CLAUDE.md sind stale (sprechen von Laravel 10 / Filament 3, Repo ist auf Laravel 13 / Filament 5 / Livewire 4). `/research`-Refresh empfohlen — separates Thema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)